### PR TITLE
Fix WinGetList() return value

### DIFF
--- a/funcs.ahk
+++ b/funcs.ahk
@@ -104,4 +104,5 @@ WinWaitNotActive.returns := Boolean
 ArrayToJs(a) => js.Array(a*)
 WinGetControls.returns := ArrayToJs
 WinGetControlsHwnd.returns := ArrayToJs
+WinGetList.returns := ArrayToJs
 ControlGetItems.returns := ArrayToJs


### PR DESCRIPTION
It looks like `WinGetList` returns an AHK array rather than a JS array.

```js
const list = winGetList("ahk_exe firefox.exe")
msgBox(typeof list) /* object */
msgBox(typeof list[0]) /* undefined */
msgBox(typeof list.findIndex) /* undefined */
msgBox(list.length) /* 1 */
```

This should fix that I think.
